### PR TITLE
Circumvent deprecation in 8.4

### DIFF
--- a/src/SocketServer.php
+++ b/src/SocketServer.php
@@ -55,7 +55,9 @@ class SocketServer extends Stream
      */
     public function setContext(array|null $options = null, array|null $params = null): self
     {
-        stream_context_set_option($this->stream, $options ?? []);
+        foreach ($options ?? [] as $key => $value) {
+            stream_context_set_option($this->stream, $key, $value);
+        }
         stream_context_set_params($this->stream, $params ?? []);
         return $this;
     }

--- a/src/SocketServer.php
+++ b/src/SocketServer.php
@@ -55,8 +55,10 @@ class SocketServer extends Stream
      */
     public function setContext(array|null $options = null, array|null $params = null): self
     {
-        foreach ($options ?? [] as $key => $value) {
-            stream_context_set_option($this->stream, $key, $value);
+        foreach ($options ?? [] as $wrapper => $wrapperOptions) {
+            foreach ($wrapperOptions ?? [] as $option => $value) {
+                stream_context_set_option($this->stream, $wrapper, $option, $value);
+            }
         }
         stream_context_set_params($this->stream, $params ?? []);
         return $this;

--- a/tests/SocketServerTest.php
+++ b/tests/SocketServerTest.php
@@ -35,9 +35,8 @@ class SocketServerTest extends TestCase
         $this->assertTrue($server->setBlocking(false));
         $this->assertFalse($server->isBlocking());
         $this->assertSame($server, $server->setContext([
-            'http' => [
-                'header' => 'Host: Test',
-                'user_agent' => 'Test',
+            'socket' => [
+                'backlog' => 1,
             ],
         ]));
         $this->assertEquals([

--- a/tests/SocketServerTest.php
+++ b/tests/SocketServerTest.php
@@ -34,7 +34,12 @@ class SocketServerTest extends TestCase
         $this->assertTrue($server->isBlocking());
         $this->assertTrue($server->setBlocking(false));
         $this->assertFalse($server->isBlocking());
-        $this->assertSame($server, $server->setContext([]));
+        $this->assertSame($server, $server->setContext([
+            'http' => [
+                'header' => 'Host: Test',
+                'user_agent' => 'Test',
+            ],
+        ]));
         $this->assertEquals([
             'timed_out' => false,
             'blocked' => false,


### PR DESCRIPTION
Circumvent deprecation warning in PHP 8.4 caused by `stream_context_set_option()`.