### PR TITLE
Add previous exception to StreamException on socket accept failure

### DIFF
--- a/src/SocketServer.php
+++ b/src/SocketServer.php
@@ -166,7 +166,7 @@ class SocketServer extends Stream
             if ($this->getMetadata('blocked') === false && substr_count($e->getMessage(), 'timed out') > 0) {
                 return null;
             }
-            throw new StreamException(StreamException::SERVER_ACCEPT_ERR);
+            throw new StreamException(StreamException::SERVER_ACCEPT_ERR, [], $e);
         });
         return $stream ? new SocketStream($stream) : null;
     }

--- a/tests/suites/SocketServerTest.php
+++ b/tests/suites/SocketServerTest.php
@@ -130,7 +130,9 @@ class SocketServerTest extends TestCase
         ], $server->getMetadata());
         $this->expectException(StreamException::class);
         $this->expectExceptionCode(StreamException::SERVER_ACCEPT_ERR);
-        $this->expectExceptionMessage('Could not accept on socket.');
+        $this->expectExceptionMessageMatches(
+            '/Could not accept on socket\. \(stream_socket_accept\(\):.*timed out.*\)/i'
+        );
         $stream = $server->accept(0);
         $server->close();
     }


### PR DESCRIPTION
Hello! 👋

I encountered an issue while working with SSL/TLS sockets where error messages were not informative enough to diagnose configuration problems.

When `stream_socket_accept()` fails due to SSL/TLS configuration issues (e.g., inaccessible private key file), the original error message was lost and final users only saw: `not accept on socket`.

Now the exception includes the original error details: `Could not accept on socket. (stream_socket_accept(): Unable to set private key file `/certs/key.pem')`

This makes debugging SSL/TLS configuration issues much easier.

Thank you for maintaining this library! Let me know if you'd like any changes to this PR.